### PR TITLE
Add the column heading to the diff table output

### DIFF
--- a/src/Belts/ConveyorBelt.php
+++ b/src/Belts/ConveyorBelt.php
@@ -230,7 +230,7 @@ abstract class ConveyorBelt
 		$this->newLine();
 		
 		$this->line(trans('conveyor-belt::messages.changes_to_record', ['record' => $this->command->getRowName()]));
-		$this->table([trans('conveyor-belt::messages.before_heading'), trans('conveyor-belt::messages.after_heading')], $table);
+		$this->table([trans('conveyor-belt::messages.column_heading'), trans('conveyor-belt::messages.before_heading'), trans('conveyor-belt::messages.after_heading')], $table);
 		
 		$this->progress->resume();
 	}

--- a/translations/en/messages.php
+++ b/translations/en/messages.php
@@ -18,6 +18,7 @@ return [
 	'record' => 'record',
 	'query_heading' => 'Query',
 	'time_heading' => 'Time',
+	'column_heading' => 'Column',
 	'before_heading' => 'Before',
 	'after_heading' => 'After',
 	'exception_heading' => 'Exception',


### PR DESCRIPTION
Right now, diffs look like:
![CleanShot 2023-02-28 at 14 38 52](https://user-images.githubusercontent.com/7297992/221974188-a58dc63c-f9d2-41b5-b80e-7cad8bf86870.png)


After, diffs look like:
![CleanShot 2023-02-28 at 14 39 19](https://user-images.githubusercontent.com/7297992/221974263-fea362f0-51a4-4984-b7ec-ce3e43fd3540.png)
